### PR TITLE
Exclude all schema.rb (multiverse compatibility)

### DIFF
--- a/0.78.0.yml
+++ b/0.78.0.yml
@@ -13,7 +13,7 @@ AllCops:
     - /**/script/**/*
     - /**/vendor/**/*
     - /**/db/migrate/**/*
-    - /**/db/schema.rb
+    - /**/db/**/schema.rb
     - /**/lib/tasks/**/*
     - /**/config/**/*
     - /**/Gemfile


### PR DESCRIPTION
Update `schema.rb` exclusion pattern to match multiple databases (multiverse). For example, `app/db/other_db/schema.rb`